### PR TITLE
Update build scripts

### DIFF
--- a/build-plugins.ps1
+++ b/build-plugins.ps1
@@ -1,13 +1,5 @@
 $pluginSrcDir = '../FileFlowsPlugins'
 
-# Create Server Plugins Folder
-$FolderName = "deploy/Plugins"
-if (!(Test-Path -Path $FolderName)) {
-    #PowerShell Create directory if not exists
-    New-Item $FolderName -ItemType Directory
-    Write-Host "Folder Created successfully"
-}
-
 # build plugin
 # build 0.0.1.0 so included one is always greater
 dotnet build Plugin\Plugin.csproj /p:WarningLevel=1 --configuration Release  /p:AssemblyVersion=0.0.1.0 /p:Version=0.0.1.0 /p:CopyRight=$copyright --output $pluginSrcDir
@@ -16,5 +8,5 @@ Remove-Item ../../FileFlowsPlugins/FileFlows.Plugin.deps.json -ErrorAction Silen
 dotnet publish PluginInfoGenerator\PluginInfoGenerator.csproj --configuration Release --output $pluginSrcDir/build/utils/PluginInfoGenerator
 
 Push-Location ../FileFlowsPlugins/build
-./buildplugins.ps1 "../../FileFlows/$FolderName"
+./buildplugins.ps1 '../../FileFlows/Server/Plugins'
 Pop-Location

--- a/build-plugins.ps1
+++ b/build-plugins.ps1
@@ -1,5 +1,13 @@
 $pluginSrcDir = '../FileFlowsPlugins'
 
+# Create Server Plugins Folder
+$FolderName = "deploy/Plugins"
+if (!(Test-Path -Path $FolderName)) {
+    #PowerShell Create directory if not exists
+    New-Item $FolderName -ItemType Directory
+    Write-Host "Folder Created successfully"
+}
+
 # build plugin
 # build 0.0.1.0 so included one is always greater
 dotnet build Plugin\Plugin.csproj /p:WarningLevel=1 --configuration Release  /p:AssemblyVersion=0.0.1.0 /p:Version=0.0.1.0 /p:CopyRight=$copyright --output $pluginSrcDir
@@ -8,5 +16,5 @@ Remove-Item ../../FileFlowsPlugins/FileFlows.Plugin.deps.json -ErrorAction Silen
 dotnet publish PluginInfoGenerator\PluginInfoGenerator.csproj --configuration Release --output $pluginSrcDir/build/utils/PluginInfoGenerator
 
 Push-Location ../FileFlowsPlugins/build
-./buildplugins.ps1 '../../FileFlows/Server/Plugins'
+./buildplugins.ps1 "../../FileFlows/$FolderName"
 Pop-Location

--- a/build/build-flowrunner.ps1
+++ b/build/build-flowrunner.ps1
@@ -2,6 +2,12 @@ Write-Output "##################################"
 Write-Output "###    Building Flow Runner    ###"
 Write-Output "##################################"
 
+if ($IsWindows) {
+    $dotnet_cmd = "dotnet.exe"
+} else {
+    $dotnet_cmd = "dotnet"
+}
+
 . .\build-variables.ps1
 
 $outdir = '../deploy/FileFlows-Runner'
@@ -10,7 +16,7 @@ $outdir = '../deploy/FileFlows-Runner'
 (Get-Content ..\FlowRunner\FlowRunner.csproj) -replace '<ProductVersion>[^<]+</ProductVersion>', "<ProductVersion>$version</ProductVersion>" | Out-File ..\FlowRunner\FlowRunner.csproj
 (Get-Content ..\FlowRunner\FlowRunner.csproj) -replace '<Copyright>[^<]+</Copyright>', "<Copyright>$copyright</Copyright>" | Out-File ..\FlowRunner\FlowRunner.csproj
   
-dotnet.exe publish '..\FlowRunner\FlowRunner.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
+& $dotnet_cmd publish '..\FlowRunner\FlowRunner.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
 
 if ((Test-Path ../deploy/FileFlows) -eq $false) {
     New-Item -Path ../deploy/FileFlows -ItemType directory

--- a/build/build-node.ps1
+++ b/build/build-node.ps1
@@ -1,3 +1,29 @@
+param(
+    [ValidateSet("True", "False", 0, 1)]
+    [ValidateNotNullOrEmpty()]
+    [string]$tar = "False"
+    , [string]$disableInstaller = "False"
+)
+
+function ConvertStringToBoolean ([string]$value) {
+    $value = $value.ToLower();
+
+    switch ($value) {
+        "true" { return $true; }
+        "1" { return $true; }
+        "false" { return $false; }
+        "0" { return $false; }
+    }
+}
+[bool]$tar_bool = ConvertStringToBoolean($tar);
+[bool]$disableInstaller_bool = ConvertStringToBoolean($disableInstaller);
+
+if ($IsWindows) {
+    $dotnet_cmd = "dotnet.exe"
+} else {
+    $dotnet_cmd = "dotnet"
+}
+
 Write-Output "#################################"
 Write-Output "###   Building Windows Node   ###"
 Write-Output "#################################"
@@ -12,28 +38,42 @@ $csVersion = "string Version = ""$version"""
 (Get-Content ..\WindowsNode\WindowsNode.csproj) -replace '<ProductVersion>[^<]+</ProductVersion>', "<ProductVersion>$version</ProductVersion>" | Out-File ..\WindowsNode\WindowsNode.csproj
 (Get-Content ..\WindowsNode\WindowsNode.csproj) -replace '<Copyright>[^<]+</Copyright>', "<Copyright>$copyright</Copyright>" | Out-File ..\WindowsNode\WindowsNode.csproj
 
-dotnet.exe publish ..\WindowsNode\WindowsNode.csproj /p:WarningLevel=1 --configuration Release /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright  /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625 --output ..\deploy\FileFlows-Node
+& $dotnet_cmd publish ..\WindowsNode\WindowsNode.csproj /p:WarningLevel=1 --configuration Release /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright  /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625 --output ..\deploy\FileFlows-Node
 
-(Get-Content installers\WindowsServerInstaller\Program.cs) -replace '([\d]+.){3}[\d]+', "$version" | Out-File  installers\WindowsServerInstaller\Program.cs -Encoding ascii
-(Get-Content installers\WindowsServerInstaller\Program.cs) -replace 'Node = false', "Node = true" | Out-File  installers\WindowsServerInstaller\Program.cs -Encoding ascii
+if (!($disableInstaller_bool)) {
+    (Get-Content installers\WindowsServerInstaller\Program.cs) -replace '([\d]+.){3}[\d]+', "$version" | Out-File  installers\WindowsServerInstaller\Program.cs -Encoding ascii
+    (Get-Content installers\WindowsServerInstaller\Program.cs) -replace 'Node = false', "Node = true" | Out-File  installers\WindowsServerInstaller\Program.cs -Encoding ascii
 
-# build the installer
-.\build-installer.ps1 .
-
-$zip = ".\deploy\FileFlows-Node-$version.zip"
-
-if ([System.IO.File]::Exists($zip)) {
-    Remove-Item $zip
+    # build the installer
+    .\build-installer.ps1 .
 }
 
-$compress = @{
-    Path             = "..\deploy\FileFlows-Node\*"
-    CompressionLevel = "Optimal"
-    DestinationPath  = "..\deploy\FileFlows-Node-$version.zip"
+
+$outdir = "..\deploy\FileFlows-Node"
+
+if (!($tar_bool)) {
+    Write-Output "Creating zip file"
+    $zip_file = "$outdir-$version.zip"
+
+    if ([System.IO.File]::Exists($zip_file)) {
+        Remove-Item $zip_file
+    }
+
+    $compress = @{
+        Path             = "$outdir\*"
+        CompressionLevel = "Optimal"
+        DestinationPath  = $zip_file
+    }
+    Compress-Archive @compress
+} else {
+    Write-Output "Creating tar file"
+    $tar_file = "$outdir-$version.tar.gz"
+
+    if ([System.IO.File]::Exists($tar_file)) {
+        Remove-Item $tar_file
+    }
+
+    tar -cvzf "$tar_file" -C "$outdir" *
 }
-Compress-Archive @compress
 
 Remove-Item ..\deploy\FileFlows-Node -Recurse -ErrorAction SilentlyContinue 
-
-
-

--- a/build/build-server.ps1
+++ b/build/build-server.ps1
@@ -1,3 +1,29 @@
+param(
+    [ValidateSet("True", "False", 0, 1)]
+    [ValidateNotNullOrEmpty()]
+    [string]$tar = "False"
+    , [string]$disableInstaller = "False"
+)
+
+function ConvertStringToBoolean ([string]$value) {
+    $value = $value.ToLower();
+
+    switch ($value) {
+        "true" { return $true; }
+        "1" { return $true; }
+        "false" { return $false; }
+        "0" { return $false; }
+    }
+}
+[bool]$tar_bool = ConvertStringToBoolean($tar);
+[bool]$disableInstaller_bool = ConvertStringToBoolean($disableInstaller);
+
+if ($IsWindows) {
+    $dotnet_cmd = "dotnet.exe"
+} else {
+    $dotnet_cmd = "dotnet"
+}
+
 Write-Output "#################################"
 Write-Output "###      Building Server      ###"
 Write-Output "#################################"
@@ -23,10 +49,10 @@ Push-Location ..\
 (Get-Content Server\Globals.cs) -replace 'public static bool Demo { get; set; } = (true|false);', "public static bool Demo { get; set; } = false;" | Out-File Server\Globals.cs
 
 (Get-Content Server\Server.csproj) -replace '<AssemblyName>[^<]+</AssemblyName>', "<AssemblyName>FileFlows.Server</AssemblyName>" | Out-File Server\Server.csproj
-dotnet.exe publish 'WindowsServer\WindowsServer.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
-dotnet.exe publish 'Server\Server.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
+& $dotnet_cmd publish 'WindowsServer\WindowsServer.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
+& $dotnet_cmd publish 'Server\Server.csproj' /p:WarningLevel=1 --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright /nowarn:CS8618 /nowarn:CS8601 /nowarn:CS8602 /nowarn:CS8603 /nowarn:CS8604 /nowarn:CS8618 /nowarn:CS8625
 
-dotnet.exe publish Client\Client.csproj --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright
+& $dotnet_cmd publish Client\Client.csproj --configuration Release --output $outdir /p:AssemblyVersion=$version /p:Version=$version /p:CopyRight=$copyright
 
 (Get-Content $outdir\wwwroot\index.html) -replace ' && location.hostname !== ''localhost''', '' | Out-File $outdir\wwwroot\index.html -encoding ascii
 Remove-Item $outdir\wwwroot\_Framework\*.dll -Recurse -ErrorAction SilentlyContinue 
@@ -40,25 +66,39 @@ if ((Test-Path deploy\plugins) -eq $true) {
     Copy-Item -Path deploy\Plugins -Filter "*.*" -Recurse -Destination $outdir\Plugins -Container
 }
 
+if (!($disableInstaller_bool)) {
+    (Get-Content build\installers\WindowsServerInstaller\Program.cs) -replace '([\d]+.){3}[\d]+', "$version" | Out-File  build\installers\WindowsServerInstaller\Program.cs -Encoding ascii
+    (Get-Content build\installers\WindowsServerInstaller\Program.cs) -replace 'Node = true', "Node = false" | Out-File  build\installers\WindowsServerInstaller\Program.cs -Encoding ascii
+
+    # build the installer
+    .\build\build-installer.ps1 build
+}
+
+if (!($tar_bool)) {
+    Write-Output "Creating zip file"
+
+    $zip_file = "$outdir-$version.zip"
+
+    if ([System.IO.File]::Exists($zip_file)) {
+        Remove-Item $zip_file
+    }
+
+    $compress = @{
+        Path             = "$outdir\*"
+        CompressionLevel = "Optimal"
+        DestinationPath  = $zip_file
+    }
+    Compress-Archive @compress
+} else {
+    Write-Output "Creating tar file"
+    $tar_file = "$outdir-$version.tar.gz"
     
-(Get-Content build\installers\WindowsServerInstaller\Program.cs) -replace '([\d]+.){3}[\d]+', "$version" | Out-File  build\installers\WindowsServerInstaller\Program.cs -Encoding ascii
-(Get-Content build\installers\WindowsServerInstaller\Program.cs) -replace 'Node = true', "Node = false" | Out-File  build\installers\WindowsServerInstaller\Program.cs -Encoding ascii
+    if ([System.IO.File]::Exists($tar_file)) {
+        Remove-Item $tar_file
+    }
 
-# build the installer
-.\build\build-installer.ps1 build
-
-$zip = "$outdir-$version.zip"
-
-if ([System.IO.File]::Exists($zip)) {
-    Remove-Item $zip
+    tar -cvzf "$tar_file" -C "$outdir" *
 }
-
-$compress = @{
-    Path             = "$outdir\*"
-    CompressionLevel = "Optimal"
-    DestinationPath  = $zip
-}
-Compress-Archive @compress
 
 Remove-Item $outdir -Recurse -ErrorAction SilentlyContinue 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,21 +1,24 @@
+param(
+    [switch]$dev = $false
+    , [switch]$tar = $false
+    , [switch]$disableInstaller = $false
+)
+
 . .\build-variables.ps1
 
 Remove-Item ../deploy/* -Recurse -Force -Exclude *.ffplugin -ErrorAction SilentlyContinue 
 
-
-$dev = $args[0] -eq '--dev'
-
 if ($dev -eq $false) {
-    if ([System.IO.Directory]::Exists("../deploy/Plugins") -eq $false) {
-        Write-Error "ERROR: No plugins directory found"
+    if (!(Test-Path -Path "../deploy/Plugins")) {
+        Write-Error "ERROR: No plugins directory found. Please run build-plugins.ps1."
         return
     }
 }
 
 .\build-spellcheck.ps1
 .\build-flowrunner.ps1
-.\build-server.ps1
-.\build-node.ps1
+.\build-server.ps1 -tar $tar -disableInstaller $disableInstaller
+.\build-node.ps1 -tar $tar -disableInstaller $disableInstaller
 
 # no longer need plugins or flowrunner, delete them
 Remove-Item ..\deploy\Plugins -Recurse -ErrorAction SilentlyContinue 


### PR DESCRIPTION
## Description
- build-node/server
  - Add tar flag to compress to tar files instead of zip so it can be used in linux
  - Add disableInstaller flag to skip the wixtoolset installer section so the msi file is not generated, this is not used by default and is used for when building this for linux or the docker containers.
- build
  - Use param to create the dev flag. This will change it from --dev to -dev
  - Add tar flag to compress to tar files instead of zip so it can be used in linux
  - Add disableInstaller flag to skip the wixtoolset installer section so the msi file is not generated, this is not used by default and is used for when building this for linux or the docker containers.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
