### PR TITLE
Docker: Remove extra PATH. Use path dotnet. Simple cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM lsiobase/ubuntu:jammy AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV PATH=$PATH:/root/.dotnet:/root/.dotnet/tools
+ENV PATH=/root/.dotnet:/root/.dotnet/tools:$PATH
 ENV DOTNET_ROOT=/root/.dotnet
 
 # Add intel hardware encoding support
@@ -36,29 +36,25 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm -rf /var/lib/apt/lists/* && \
     ffmpeg --help
 
-##########################################
-### actual FileFlows stuff happens now ###
-##########################################
-FROM base
-
 # Install dotnet SDK
 RUN wget https://dot.net/v1/dotnet-install.sh  && \
     bash dotnet-install.sh -c Current && \
     rm -f dotnet-install.sh
+
+##########################################
+### actual FileFlows stuff happens now ###
+##########################################
 
 # copy the deploy file into the app directory
 COPY /deploy /app
 COPY /deploy/Plugins /app/Server/Plugins
 COPY /docker-entrypoint.sh /app/docker-entrypoint.sh
 
-# expose the ports we need
-EXPOSE 5000
-
 RUN dos2unix /app/docker-entrypoint.sh && \
     chmod +x /app/docker-entrypoint.sh
 
-# add dotnet to path so can run dotnet anywhere
-ENV PATH="/root/.dotnet:${PATH}"
+# expose the ports we need
+EXPOSE 5000
 
 # set the working directory
 WORKDIR /app

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,8 +16,8 @@ if [[ "$FFNODE" == 'true' || "$FFNODE" == '1' || "$1" = '--node' ]]; then
 
     printf "Launching node\n"
     cd /app/Node
-    exec /root/.dotnet/dotnet FileFlows.Node.dll --docker true
-    
+    exec dotnet FileFlows.Node.dll --docker true
+
 else
 
     # check if there is an upgrade to apply
@@ -31,5 +31,5 @@ else
 
     printf "Launching server\n"
     cd /app/Server
-    exec /root/.dotnet/dotnet FileFlows.Server.dll --urls=http://*:5000 --docker
+    exec dotnet FileFlows.Server.dll --urls=http://*:5000 --docker
 fi


### PR DESCRIPTION
Remove extra PATH env
Remove FROM base as we are not actually using mutlistage building so it serves no purpose
Move expose to the bottom

Use the dotnet in the PATH for the docker-entrypoint instead of hardcoding the path
Add new lines to the end of the files to follow standards.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
