### PR TITLE
Fix node max file size setting not being used

### DIFF
--- a/Server/Services/LibraryFileService.cs
+++ b/Server/Services/LibraryFileService.cs
@@ -142,11 +142,11 @@ public partial class LibraryFileService : ILibraryFileService
             if (libFile == null)
                 return null;
 
-            // At this point, libFile will contain either the next file to process (if any file has been moved to top),
+            // At this point, libFile will contain either the next file to process if any file has been moved to top,
             // or the latest modified file from the highest priority library.
             // Since this does not take into account individual library ordering, determine the library of the file selected
-            // (should be the highest priority), then run the query again but only for that library and with the ordering
-            // set as per the library settings.
+            // (should be the highest priority). Then, if the library has a processing order set, run the query again but only
+            // for that library and with the ordering set as per the library settings.
             var library = libraries.FirstOrDefault(x => x.Uid == libFile.LibraryUid);
             if (libFile.Order < 1 && library != null && library.ProcessingOrder != ProcessingOrder.AsFound)
             {

--- a/Server/Services/LibraryFileService.cs
+++ b/Server/Services/LibraryFileService.cs
@@ -127,6 +127,11 @@ public partial class LibraryFileService : ILibraryFileService
             var execAndWhere = executing?.Any() != true
                 ? string.Empty
                 : (" and LibraryFile.Uid not in (" + string.Join(",", executing.Select(x => "'" + x + "'")) + ") ");
+
+            // Add node file size restriction
+            execAndWhere += node.MaxFileSizeMb > 0
+                ? $"and OriginalSize <= {node.MaxFileSizeMb * 1000000}"
+                : string.Empty;
             
             string sql = $"select * from LibraryFile {LIBRARY_JOIN} where Status = 0 and HoldUntil <= " + SqlHelper.Now() +
                          $" and LibraryUid in ({libraryUids}) " + execAndWhere +

--- a/Server/Services/LibraryFileService.cs
+++ b/Server/Services/LibraryFileService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using FileFlows.Server.Helpers;
 using FileFlows.ServerShared.Models;
 using FileFlows.Server.Controllers;
@@ -137,7 +137,11 @@ public partial class LibraryFileService : ILibraryFileService
             if (libFile == null)
                 return null;
 
-            // check the library this file belongs, we may have to grab a different file from this library
+            // At this point, libFile will contain either the next file to process (if any file has been moved to top),
+            // or the latest modified file from the highest priority library.
+            // Since this does not take into account individual library ordering, determine the library of the file selected
+            // (should be the highest priority), then run the query again but only for that library and with the ordering
+            // set as per the library settings.
             var library = libraries.FirstOrDefault(x => x.Uid == libFile.LibraryUid);
             if (libFile.Order < 1 && library != null && library.ProcessingOrder != ProcessingOrder.AsFound)
             {

--- a/Shared/Models/LibraryFile.cs
+++ b/Shared/Models/LibraryFile.cs
@@ -196,6 +196,9 @@ public class LibraryFile : FileFlowObject
     /// <summary>
     /// Gets or sets the order of the file when the file should be processed
     /// </summary>
+    /// <remarks>
+    /// 0 indicates no order has been set. Values higher than 1 indicate ordering in ascending order (i.e. 1 will be processed first).
+    /// </remarks>
     [Column("ProcessingOrder")]
     public int Order { get; set; }
 


### PR DESCRIPTION
## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.

## Description

I had a node configured with a max file size but it was still picking up larger files. The setting was missing from the query when determining the next file to process.

I've also updated the comment with my understanding of this code as it took a while to understand. Hopefully I've understood correctly how it works and what it is doing.

## Testing

I've tested using the internal node and by generating files using `dd if=/dev/zero of=./test_file bs=1MB count=3` and again changing the file name and count. The file under the limit was processed as expected. The file over the limit remained in the processing queue and wasn't picked up.