### PR TITLE
Fix PUID not being used correctly in entrypoint script

### DIFF
--- a/Server/docker-entrypoint.sh
+++ b/Server/docker-entrypoint.sh
@@ -149,7 +149,7 @@ else
 
     if id "${PUID}" &>/dev/null; then
         printf "${PUID} user exists\n"
-        user="$(id -u -n)"
+        user="$(id -u -n ${PUID})"
     else
         if [ $(getent group $pgid) ]; then
             printf "group $pgid exists\n"


### PR DESCRIPTION
The PUID that gets passed into the docker environment doesn't actually get used in the entrypoint script. I found this bug when I realised that processes were running as `root` instead of my `nobody` user on unraid

Logs from the bugginess (the 99 user is correct, the changing ownership is correct, but then it launches using the username `root` instead of `nobody`):

```
99 user exists
changing owner of /app to: 99:100
changed owner of /app to: 99:100
passwd: password changed
Launching server as `root`
```

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
