### PR TITLE
Create PGIDS groups if they do not exist

### DIFF
--- a/Server/docker-entrypoint.sh
+++ b/Server/docker-entrypoint.sh
@@ -176,8 +176,9 @@ else
             if [[ "$group" =~ ^[0-9]+$ ]]; then
                 group_name=$(getent group "$group" | cut -d: -f1)
                 if [[ -z "$group_name" ]]; then
-                    printf "Group with GID $group does not exist\n"
-                    continue
+                    printf "Group with GID $group does not exist, creating\n"
+                    group_name=fileflows$group
+                    groupadd -g $group $group_name
                 fi
             else
                 group_name="$group"


### PR DESCRIPTION
Fix an issue where trying to add a non-existing group in the container using PGIDS would not happen.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
