### PR TITLE
Fix container images installing software-properties-common

### DIFF
--- a/xBuild/Dockerfile
+++ b/xBuild/Dockerfile
@@ -10,9 +10,6 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository universe && \
-    apt-get update && \
     apt-get install -y tzdata wget ca-certificates gnupg curl tar xz-utils libssl-dev apt-transport-https openssl locales libfontconfig1 libfreetype6 pciutils vainfo git
 
 # Install dotnet SDK
@@ -23,7 +20,7 @@ RUN wget https://dot.net/v1/dotnet-install.sh  && \
 
 # Install Docker
 RUN curl -fsSL https://get.docker.com | sh
-    
+
 ##########################################
 ### actual FileFlows stuff happens now ###
 ##########################################

--- a/xBuild/DockerfileModded
+++ b/xBuild/DockerfileModded
@@ -12,9 +12,6 @@ ENV LIBVA_DRIVERS_PATH="/usr/lib/x86_64-linux-gnu/dri" \
     DOTNET_CLI_TELEMETRY_OPTOUT=true
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository universe && \
-    apt-get update && \
     apt-get install -y tzdata wget ca-certificates gnupg curl tar xz-utils libssl-dev apt-transport-https openssl locales libfontconfig1 libfreetype6 pciutils vainfo git pip
     
 # MODS# Install mods and architecture-specific packages


### PR DESCRIPTION
It looks like `software-properties-common` is installed exclusively so that the `add-apt-repository` command can be used to add the `universe` component to Ubuntu repos. This package has an enormous number of dependencies, which bloat the image size.

The `universe` component is pre-enabled on the base `ubuntu:24.04` image, making the `add-apt-repository universe` command superfluous. As a result, both this, the additional `apt update`, and all these other dependencies can be removed.

```console
$ docker run --rm ubuntu:24.04 cat /etc/apt/sources.list.d/ubuntu.sources | grep -v '^#'

Types: deb
URIs: http://archive.ubuntu.com/ubuntu/
Suites: noble noble-updates noble-backports
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

Types: deb
URIs: http://security.ubuntu.com/ubuntu/
Suites: noble-security
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
```

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
