### PR TITLE
Run ab-av1 - add scoring cache directory

### DIFF
--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -113,6 +113,7 @@ function search(abav1Command){
                 `PATH=${path}:$PATH ` + 
                 abav1Command
             ];
+    executeArgs.EnvironmentalVariables["XDG_CACHE_HOME"] = `${Variables.temp}`
     let returnValue = {
         data: [
             // { crf: 12, score: 12.34, size: 90 }

--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -6,7 +6,7 @@ If CRF is found, it is saved to Variables.AbAv1CRFValue.
 Executes the ab-av1 command.
  * @author CanofSocks
  * @uid e31fbd4d-dc96-4ae6-9122-a9f30c102b1d
- * @revision 8
+ * @revision 9
  * @param {string} Preset The preset to use
  * @param {string} Encoder The target encoder
  * @param {string} EncOptions A '|' separated list of additional options to pass to ab-av1. The first '=' symbol will be used to infer that this is an option with a value. Passed to ffmpeg like "x265-params=lossless=1" -> ['-x265-params', 'lossless=1'] 


### PR DESCRIPTION
Add valid directory for ab-av1 scoring cache to be flow's temp directory
## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
